### PR TITLE
Track story id by branch

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
+--require spec_helper
 --format documentation
 --color

--- a/bin/pf-prepare-commit-msg
+++ b/bin/pf-prepare-commit-msg
@@ -3,7 +3,7 @@
 branch_name = `git symbolic-ref HEAD 2>/dev/null | cut -d '/' -f3`.strip
 story_path = "tmp/.pivo_flow/stories/#{branch_name}"
 
-if File.exists?(story_path)
+if !branch_name.empty? && File.exists?(story_path)
   story_id = File.read(story_path).strip
 
   if story_id =~ /(\d{7,})/

--- a/bin/pf-prepare-commit-msg
+++ b/bin/pf-prepare-commit-msg
@@ -5,10 +5,12 @@ story_path = "tmp/.pivo_flow/stories/#{branch_name}"
 
 if File.exists?(story_path)
   story_id = File.read(story_path).strip
+
   if story_id =~ /(\d{7,})/
     puts IO.read(ARGV[0])
     commit_msg = IO.read(ARGV[0])
-    unless commit_msg.include?($1) or commit_msg =~ /Merge branch/
+
+    unless commit_msg.include?("##{$1}") or commit_msg =~ /Merge branch/
       File.open(ARGV[0], 'w') do |file|
         file.print commit_msg
         file.print "[##{story_id}]"

--- a/bin/pf-prepare-commit-msg
+++ b/bin/pf-prepare-commit-msg
@@ -1,5 +1,8 @@
 #!/usr/bin/env ruby
-story_path = 'tmp/.pivotal_story_id'
+
+branch_name = `git symbolic-ref HEAD 2>/dev/null | cut -d '/' -f3`.strip
+story_path = "tmp/.pivo_flow/stories/#{branch_name}"
+
 if File.exists?(story_path)
   story_id = File.read(story_path).strip
   if story_id =~ /(\d{7,})/

--- a/lib/pivo_flow.rb
+++ b/lib/pivo_flow.rb
@@ -5,6 +5,7 @@ require 'highline'
 require 'fileutils'
 require 'pivotal-tracker'
 
+require 'pivo_flow/state'
 require 'pivo_flow/core_extensions'
 require 'pivo_flow/errors'
 require 'pivo_flow/version'

--- a/lib/pivo_flow/cli.rb
+++ b/lib/pivo_flow/cli.rb
@@ -1,8 +1,8 @@
 module PivoFlow
   class Cli
+    include PivoFlow::State
 
     def initialize *args
-      @file_story_path = File.join(Dir.pwd, "/tmp/.pivotal_story_id")
       @args = args
     end
 
@@ -58,7 +58,7 @@ module PivoFlow
 
     def clear
       unless current_story_id.nil?
-        FileUtils.remove_file(@file_story_path)
+        FileUtils.remove_file(current_story_id_file_path)
         puts "Current pivotal story id cleared."
       else
         puts no_story_found_message
@@ -98,7 +98,7 @@ module PivoFlow
     end
 
     def no_story_found_message
-      "No story found in #{@file_story_path}"
+      "No story found in #{current_story_id_file_path}"
     end
 
     def no_method_error
@@ -107,11 +107,6 @@ module PivoFlow
 
     def invalid_method_error
       puts "Ups, no such method..."
-    end
-
-    def current_story_id
-      return nil unless File.exists?(@file_story_path)
-      File.open(@file_story_path).read.strip
     end
 
     def parse_argv(args)

--- a/lib/pivo_flow/pivotal.rb
+++ b/lib/pivo_flow/pivotal.rb
@@ -256,13 +256,8 @@ module PivoFlow
     end
 
     def save_story_id_to_file story_id
-      ensure_tmp_directory_exists
-
-      File.open(current_story_id_file_path, 'w') { |f| f.write(story_id) }
-    end
-
-    def ensure_tmp_directory_exists
       FileUtils.mkdir_p(story_id_tmp_path)
+      File.open(current_story_id_file_path, 'w') { |f| f.write(story_id) }
     end
 
     def show_stories count=9

--- a/lib/pivo_flow/state.rb
+++ b/lib/pivo_flow/state.rb
@@ -1,0 +1,21 @@
+module PivoFlow
+  module State
+    extend self
+
+    def current_branch_name
+      `git symbolic-ref HEAD 2>/dev/null | cut -d '/' -f3`.strip
+    end
+
+    def story_id_tmp_path
+      "#{Dir.pwd}/tmp/.pivo_flow/stories"
+    end
+
+    def current_story_id_file_path
+      File.join(story_id_tmp_path, current_branch_name)
+    end
+
+    def current_story_id
+      File.read(current_story_id_file_path)
+    end
+  end
+end

--- a/lib/pivo_flow/state.rb
+++ b/lib/pivo_flow/state.rb
@@ -3,7 +3,7 @@ module PivoFlow
     extend self
 
     def current_branch_name
-      `git symbolic-ref HEAD 2>/dev/null | cut -d '/' -f3`.strip
+      Grit::Repo.new(Dir.pwd).head.name
     end
 
     def story_id_tmp_path
@@ -15,6 +15,8 @@ module PivoFlow
     end
 
     def current_story_id
+      return nil unless File.exist?(current_story_id_file_path)
+
       File.read(current_story_id_file_path)
     end
   end

--- a/pivo_flow.gemspec
+++ b/pivo_flow.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
   gem.add_development_dependency "vcr"
   gem.add_development_dependency "fakeweb"
-
 end

--- a/spec/pivo_flow/base_spec.rb
+++ b/spec/pivo_flow/base_spec.rb
@@ -1,23 +1,27 @@
 require "spec_helper"
 require_relative './../../lib/pivo_flow/errors'
-describe PivoFlow::Base do
 
+describe PivoFlow::Base do
   let(:base) { PivoFlow::Base.new }
 
   before do
-    PivoFlow::Base.any_instance.stub(:puts)
+    allow_any_instance_of(PivoFlow::Base).to receive(:puts)
+
     stub_git_config
     stub_base_methods(PivoFlow::Base)
   end
 
   it "raises exception if it's outside of git repo" do
-    PivoFlow::Base.any_instance.stub(:git_directory_present?).and_return(false)
-    expect{base}.to raise_error(PivoFlow::Errors::NoGitRepoFound)
+    allow_any_instance_of(PivoFlow::Base).to receive(:git_directory_present?)
+      .and_return(false)
+
+    expect{ base }.to raise_error(PivoFlow::Errors::NoGitRepoFound)
   end
 
   it "calls hook installation if it's needed" do
-    PivoFlow::Base.any_instance.stub(:git_hook_needed?).and_return(true)
-    PivoFlow::Base.any_instance.should_receive(:install_git_hook)
+    allow_any_instance_of(PivoFlow::Base).to receive(:git_hook_needed?).and_return(true)
+    allow_any_instance_of(PivoFlow::Base).to receive(:install_git_hook)
+
     base
   end
 
@@ -33,13 +37,13 @@ describe PivoFlow::Base do
 
     it "creates an executable prepare-commit-msg file" do
       base.install_git_hook
-      File.executable?(file_name).should be_true
+      File.executable?(file_name).should be_truthy
     end
 
     it "creates an executable pf-prepare-commit-msg file" do
       File.delete pf_file_name if File.exists? pf_file_name
       base.install_git_hook
-      File.executable?(pf_file_name).should be_true
+      File.executable?(pf_file_name).should be_truthy
     end
 
   end
@@ -67,18 +71,16 @@ describe PivoFlow::Base do
         'pivo-flow.api-token' => nil,
         'pivo-flow.project-id' => nil}
         )
-      PivoFlow::Base.any_instance.stub(:git_config_ok?).and_return(false)
 
+      allow_any_instance_of(PivoFlow::Base).to receive(:git_config_ok?).and_return(false)
     end
 
     PivoFlow::Base::KEYS_AND_QUESTIONS.each do |key, value|
       it "changes #{key} value" do
-        PivoFlow::Base.any_instance.stub(:ask_question).and_return(key)
+        allow_any_instance_of(PivoFlow::Base).to receive(:ask_question).and_return(key)
         new_key = key.split(".").last
         base.options[new_key].should eq key
       end
     end
-
   end
-
 end

--- a/spec/pivo_flow/base_spec.rb
+++ b/spec/pivo_flow/base_spec.rb
@@ -37,13 +37,13 @@ describe PivoFlow::Base do
 
     it "creates an executable prepare-commit-msg file" do
       base.install_git_hook
-      File.executable?(file_name).should be_truthy
+      expect(File.executable?(file_name)).to be_truthy
     end
 
     it "creates an executable pf-prepare-commit-msg file" do
       File.delete pf_file_name if File.exists? pf_file_name
       base.install_git_hook
-      File.executable?(pf_file_name).should be_truthy
+      expect(File.executable?(pf_file_name)).to be_truthy
     end
 
   end
@@ -51,15 +51,15 @@ describe PivoFlow::Base do
   describe "parses git config" do
 
     it "and returns project id" do
-      base.options["project-id"].should eq "123456"
+      expect(base.options["project-id"]).to eq "123456"
     end
 
     it "and returns api token" do
-      base.options["api-token"].should eq "testtesttesttesttesttesttesttest"
+      expect(base.options["api-token"]).to eq "testtesttesttesttesttesttesttest"
     end
 
     it "returns user name" do
-      base.user_name.should eq "Adam Newman"
+      expect(base.user_name).to eq "Adam Newman"
     end
 
   end
@@ -79,7 +79,7 @@ describe PivoFlow::Base do
       it "changes #{key} value" do
         allow_any_instance_of(PivoFlow::Base).to receive(:ask_question).and_return(key)
         new_key = key.split(".").last
-        base.options[new_key].should eq key
+        expect(base.options[new_key]).to eq key
       end
     end
   end

--- a/spec/pivo_flow/cli_spec.rb
+++ b/spec/pivo_flow/cli_spec.rb
@@ -4,7 +4,7 @@ describe PivoFlow::Cli do
 
   before(:each) do
     # we don't need cli output all over the specs
-    PivoFlow::Cli.any_instance.stub(:puts)
+    allow_any_instance_of(PivoFlow::Cli).to receive(:puts)
   end
 
   describe "with no args provided" do
@@ -12,7 +12,7 @@ describe PivoFlow::Cli do
     let(:command) { PivoFlow::Cli.new.go! }
 
     before(:each) do
-      PivoFlow::Cli.any_instance.should_receive(:no_method_error).and_return(true)
+      expect_any_instance_of(PivoFlow::Cli).to receive(:no_method_error).and_return(true)
     end
 
     it "calls no_method_error message " do
@@ -30,7 +30,7 @@ describe PivoFlow::Cli do
     let(:command) { PivoFlow::Cli.new("invalid_method_name").go! }
 
     before(:each) do
-      PivoFlow::Cli.any_instance.should_receive(:invalid_method_error)
+      expect_any_instance_of(PivoFlow::Cli).to receive(:invalid_method_error)
     end
 
     it "calls invalid_method_error message" do
@@ -44,11 +44,11 @@ describe PivoFlow::Cli do
   end
 
   describe "with valid command" do
-    cmd = "stories"
+    let(:cmd) { "stories" }
     let(:command) { PivoFlow::Cli.new(cmd).go! }
 
     before do
-      PivoFlow::Cli.any_instance.should_receive(cmd.to_sym)
+      expect_any_instance_of(PivoFlow::Cli).to receive(cmd.to_sym)
     end
 
     it "runs this command if it is public" do
@@ -58,44 +58,27 @@ describe PivoFlow::Cli do
     it "returns 0" do
       expect(command).to eq 0
     end
-
-  end
-
-  describe "reads story id from file" do
-
-    it "and returns nil if there is no such file" do
-      File.stub(:exists?).and_return(false)
-      PivoFlow::Cli.new.send(:current_story_id).should be_nil
-    end
-
-    it "and returns story id if file exists" do
-      File.stub(:exists?).and_return(true)
-      f = instance_double('File', :read => "123")
-      File.stub(:open).and_return(f)
-      PivoFlow::Cli.new.send(:current_story_id).should eq "123"
-    end
   end
 
   describe "finish method" do
-
     it "calls finish_story on pivotal object on finish method" do
       pivo = instance_double("PivoFlow::Pivotal")
-      PivoFlow::Cli.any_instance.should_receive(:pivotal_object).and_return(pivo)
-      pivo.should_receive(:finish_story).with("123")
-      PivoFlow::Cli.any_instance.should_receive(:current_story_id).twice.and_return("123")
+      expect_any_instance_of(PivoFlow::Cli).to receive(:pivotal_object).and_return(pivo)
+      expect(pivo).to receive(:finish_story).with("123")
+      expect_any_instance_of(PivoFlow::Cli).to receive(:current_story_id).twice.and_return("123")
       PivoFlow::Cli.new("finish").go!
     end
 
     it "returns 1 if there is no current_story_id" do
-      PivoFlow::Cli.any_instance.should_receive(:current_story_id).and_return(nil)
-      PivoFlow::Cli.new.send(:finish).should eq 1
+      expect_any_instance_of(PivoFlow::Cli).to receive(:current_story_id).and_return(nil)
+      expect(PivoFlow::Cli.new.send(:finish)).to eq 1
     end
   end
 
   describe "start method" do
 
     it "returns 1 if no story given" do
-      PivoFlow::Cli.new.send(:start).should eq 1
+      expect(PivoFlow::Cli.new.send(:start)).to eq 1
     end
 
   end
@@ -103,14 +86,14 @@ describe PivoFlow::Cli do
   describe "clear method" do
 
     it "returns 1 if current story is nil" do
-      PivoFlow::Cli.any_instance.should_receive(:current_story_id).and_return(nil)
-      PivoFlow::Cli.new.send(:clear).should eq 1
+      expect_any_instance_of(PivoFlow::Cli).to receive(:current_story_id).and_return(nil)
+      expect(PivoFlow::Cli.new.send(:clear)).to eq 1
     end
 
 
     it "removes file if current story is present" do
-      PivoFlow::Cli.any_instance.should_receive(:current_story_id).and_return(1)
-      FileUtils.should_receive(:remove_file).and_return(true)
+      expect_any_instance_of(PivoFlow::Cli).to receive(:current_story_id).and_return(1)
+      expect(FileUtils).to receive(:remove_file).and_return(true)
       PivoFlow::Cli.new.send(:clear)
     end
 
@@ -121,8 +104,8 @@ describe PivoFlow::Cli do
     methods = [:stories, :start, :info, :finish, :clear, :help, :reconfig, :current, :deliver]
     methods.each do |method|
       it "#{method.to_s}" do
-        PivoFlow::Cli.any_instance.stub(method)
-        PivoFlow::Cli.new(method.to_s).go!.should eq 0
+        allow_any_instance_of(PivoFlow::Cli).to receive(method)
+        expect(PivoFlow::Cli.new(method.to_s).go!).to eq 0
       end
     end
   end

--- a/spec/pivo_flow/cli_spec.rb
+++ b/spec/pivo_flow/cli_spec.rb
@@ -70,7 +70,7 @@ describe PivoFlow::Cli do
 
     it "and returns story id if file exists" do
       File.stub(:exists?).and_return(true)
-      f = mock('File', :read => "123")
+      f = instance_double('File', :read => "123")
       File.stub(:open).and_return(f)
       PivoFlow::Cli.new.send(:current_story_id).should eq "123"
     end
@@ -79,7 +79,7 @@ describe PivoFlow::Cli do
   describe "finish method" do
 
     it "calls finish_story on pivotal object on finish method" do
-      pivo = mock("PivoFlow::Pivotal")
+      pivo = instance_double("PivoFlow::Pivotal")
       PivoFlow::Cli.any_instance.should_receive(:pivotal_object).and_return(pivo)
       pivo.should_receive(:finish_story).with("123")
       PivoFlow::Cli.any_instance.should_receive(:current_story_id).twice.and_return("123")

--- a/spec/pivo_flow/pivotal_spec.rb
+++ b/spec/pivo_flow/pivotal_spec.rb
@@ -6,34 +6,37 @@ describe PivoFlow::Pivotal do
 
   before do
     stub_git_config
-    PivoFlow::Pivotal.any_instance.stub(:puts)
+
+    allow_any_instance_of(PivoFlow::Pivotal).to receive(:puts)
+
     stub_base_methods(PivoFlow::Pivotal)
   end
 
   describe "raises exception" do
     it "when project id is incorrect" do
       VCR.use_cassette(:pivotal_fetch_project_not_found) do
-        expect{pivotal.fetch_stories}.to raise_error(PivoFlow::Errors::UnsuccessfulPivotalConnection)
+        expect{ pivotal.fetch_stories }.to \
+          raise_error(PivoFlow::Errors::UnsuccessfulPivotalConnection)
       end
     end
 
     it "when api-token is incorrect (unauthorized)" do
       VCR.use_cassette(:pivotal_fetch_project_unauthorized) do
-        expect{pivotal.fetch_stories}.to raise_error(PivoFlow::Errors::UnsuccessfulPivotalConnection)
+        expect{ pivotal.fetch_stories }.to \
+          raise_error(PivoFlow::Errors::UnsuccessfulPivotalConnection)
       end
     end
 
   end
 
   describe "methods" do
-
     before(:each) do
       stub_pivotal_project
       pivotal.run
     end
 
     it "does not call pivotal upon run" do
-      pivotal.options[:project].should be_nil
+      expect(pivotal.options[:project]).to be_nil
     end
 
     it "calls pivotal when necessary" do
@@ -148,9 +151,8 @@ describe PivoFlow::Pivotal do
       end
 
       it "returns true on success" do
-        pivotal.start_story(@story_feature.id).should be_true
+        pivotal.start_story(@story_feature.id).should be_truthy
       end
-
     end
 
     it "show_info returns 1 if there is no story" do
@@ -206,10 +208,11 @@ describe PivoFlow::Pivotal do
       labels: "first,second"
     )
 
-    @story_feature.stub_chain(:update).and_return(mock(errors: []))
+    @story_feature.stub_chain(:update).and_return(double(errors: []))
     @story_unassigned = PivotalTracker::Story.new(owned_by: nil, name: "test", current_state: "started")
     @story_rejected = PivotalTracker::Story.new(current_state: "rejected", owned_by: "Mark Marco", name: "test_rejected")
     @story_finished = PivotalTracker::Story.new(current_state: "finished", owned_by: "Mark Marco", name: "finished")
+
     @project.stub_chain(:stories, :all).and_return([@story_feature, @story_unassigned, @story_rejected, @story_finished])
     PivotalTracker::Project.stub(:find).and_return(@project)
   end

--- a/spec/pivo_flow/pivotal_spec.rb
+++ b/spec/pivo_flow/pivotal_spec.rb
@@ -188,27 +188,29 @@ describe PivoFlow::Pivotal do
 
   end
 
-end
+  def stub_pivotal_project
+    @project = PivotalTracker::Project.new(id: 123456, name: "testproject")
 
-def stub_pivotal_project
-  @project = PivotalTracker::Project.new(id: 123456, name: "testproject")
-  @story_feature = PivotalTracker::Story.new(
-    id: 1,
-    url: "http://www.pivotaltracker.com/story/show/1",
-    created_at: DateTime.now,
-    project_id: 123456,
-    name: "story no 1",
-    description: "story description",
-    story_type: "feature",
-    estimate: 3,
-    current_state: "started",
-    requested_by: "Paul Newman",
-    owned_by: "Adam Newman",
-    labels: "first,second")
-  @story_feature.stub_chain(:update).and_return(mock(errors: []))
-  @story_unassigned = PivotalTracker::Story.new(owned_by: nil, name: "test", current_state: "started")
-  @story_rejected = PivotalTracker::Story.new(current_state: "rejected", owned_by: "Mark Marco", name: "test_rejected")
-  @story_finished = PivotalTracker::Story.new(current_state: "finished", owned_by: "Mark Marco", name: "finished")
-  @project.stub_chain(:stories, :all).and_return([@story_feature, @story_unassigned, @story_rejected, @story_finished])
-  PivotalTracker::Project.stub(:find).and_return(@project)
+    @story_feature = PivotalTracker::Story.new(
+      id: 1,
+      url: "http://www.pivotaltracker.com/story/show/1",
+      created_at: DateTime.now,
+      project_id: 123456,
+      name: "story no 1",
+      description: "story description",
+      story_type: "feature",
+      estimate: 3,
+      current_state: "started",
+      requested_by: "Paul Newman",
+      owned_by: "Adam Newman",
+      labels: "first,second"
+    )
+
+    @story_feature.stub_chain(:update).and_return(mock(errors: []))
+    @story_unassigned = PivotalTracker::Story.new(owned_by: nil, name: "test", current_state: "started")
+    @story_rejected = PivotalTracker::Story.new(current_state: "rejected", owned_by: "Mark Marco", name: "test_rejected")
+    @story_finished = PivotalTracker::Story.new(current_state: "finished", owned_by: "Mark Marco", name: "finished")
+    @project.stub_chain(:stories, :all).and_return([@story_feature, @story_unassigned, @story_rejected, @story_finished])
+    PivotalTracker::Project.stub(:find).and_return(@project)
+  end
 end

--- a/spec/pivo_flow/state_spec.rb
+++ b/spec/pivo_flow/state_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe PivoFlow::State do
+  describe "#current_story_id_file_path" do
+    before do
+      allow(PivoFlow::State).to receive(:current_branch_name) { "cool-branch" }
+    end
+
+    it "should return a path to a branch-based file name" do
+      expect(PivoFlow::State.current_story_id_file_path).to eq(
+        ".tmp/pivo_flow/stories/cool-branch"
+      )
+    end
+  end
+
+  describe "#current_story_id" do
+    let(:tmp_file) { ".tmp/pivo_flow/stories/cool-branch" }
+
+    before do
+      allow(PivoFlow::State).to receive(:current_branch_name) { "cool-branch" }
+
+      FileUtils.mkdir_p(PivoFlow::State.story_id_tmp_path)
+      File.write(tmp_file, "123456")
+    end
+
+    after { FileUtils.remove_file(tmp_file) }
+
+    it "should read it from the tmp file" do
+      expect(PivoFlow::State.current_story_id).to eq("123456")
+    end
+  end
+end

--- a/spec/pivo_flow/state_spec.rb
+++ b/spec/pivo_flow/state_spec.rb
@@ -8,13 +8,13 @@ describe PivoFlow::State do
 
     it "should return a path to a branch-based file name" do
       expect(PivoFlow::State.current_story_id_file_path).to eq(
-        ".tmp/pivo_flow/stories/cool-branch"
+        "#{Dir.pwd}/tmp/.pivo_flow/stories/cool-branch"
       )
     end
   end
 
   describe "#current_story_id" do
-    let(:tmp_file) { ".tmp/pivo_flow/stories/cool-branch" }
+    let(:tmp_file) { "#{Dir.pwd}/tmp/.pivo_flow/stories/cool-branch" }
 
     before do
       allow(PivoFlow::State).to receive(:current_branch_name) { "cool-branch" }

--- a/spec/pivo_flow/state_spec.rb
+++ b/spec/pivo_flow/state_spec.rb
@@ -28,5 +28,11 @@ describe PivoFlow::State do
     it "should read it from the tmp file" do
       expect(PivoFlow::State.current_story_id).to eq("123456")
     end
+
+    it "should return nil if there's no file for it yet" do
+      allow(PivoFlow::State).to receive(:current_branch_name) { "different" }
+
+      expect(PivoFlow::State.current_story_id).to be_nil
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,18 +12,24 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/pivo_flow/vcr_cassettes'
 end
 
-def stub_git_config(options = {})
-  git_options = {
-    "pivo-flow.api-token" => "testtesttesttesttesttesttesttest",
-    "pivo-flow.project-id" => "123456",
-    "user.name" => "Adam Newman"
-  }.merge options
-  Grit::Repo.stub!(:new).and_return mock('Grit::Repo', :config => git_options)
+module StubHelpers
+  def stub_git_config(options = {})
+    git_options = {
+      "pivo-flow.api-token" => "testtesttesttesttesttesttesttest",
+      "pivo-flow.project-id" => "123456",
+      "user.name" => "Adam Newman"
+    }.merge options
 
+    Grit::Repo.stub!(:new).and_return mock('Grit::Repo', :config => git_options)
+  end
+
+  def stub_base_methods(klass)
+    klass.any_instance.stub(:git_hook_needed?).and_return(false)
+    klass.any_instance.stub(:git_directory_present?).and_return(true)
+    klass.any_instance.stub(:git_config_ok?).and_return(true)
+  end
 end
 
-def stub_base_methods(klass)
- klass.any_instance.stub(:git_hook_needed?).and_return(false)
- klass.any_instance.stub(:git_directory_present?).and_return(true)
- klass.any_instance.stub(:git_config_ok?).and_return(true)
+RSpec.configure do |config|
+  config.include StubHelpers
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,15 +18,17 @@ module StubHelpers
       "pivo-flow.api-token" => "testtesttesttesttesttesttesttest",
       "pivo-flow.project-id" => "123456",
       "user.name" => "Adam Newman"
-    }.merge options
+    }.merge(options)
 
-    Grit::Repo.stub!(:new).and_return mock('Grit::Repo', :config => git_options)
+    allow(Grit::Repo).to receive(:new) do
+      instance_double('Grit::Repo', :config => git_options)
+    end
   end
 
   def stub_base_methods(klass)
-    klass.any_instance.stub(:git_hook_needed?).and_return(false)
-    klass.any_instance.stub(:git_directory_present?).and_return(true)
-    klass.any_instance.stub(:git_config_ok?).and_return(true)
+    allow_any_instance_of(klass).to receive(:git_hook_needed?) { false }
+    allow_any_instance_of(klass).to receive(:git_directory_present?) { true }
+    allow_any_instance_of(klass).to receive(:git_config_ok?) { true }
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ module StubHelpers
     }.merge(options)
 
     allow(Grit::Repo).to receive(:new) do
-      instance_double('Grit::Repo', :config => git_options)
+      instance_double('Grit::Repo', config: git_options)
     end
   end
 


### PR DESCRIPTION
@lubieniebieski 

Since there is the `pf branch` feature, I wanted to also support having different story IDs per branch. Things this branch ended up having:

* seamlessly updates the story ID as you `git checkout` different branches
* works with a only-commit-to-master style of development as well as branching workflow
* cleans up a lot of duplicated information (all the paths are in one place, getting the story ID is in one place)
* updates the prepare hook
* fixes a bug in the prepare hook where it wasn't adding the [#id] tag when doing a `git commit` in the editor, due to the `pf branch` name already containing the `#id`
* fixes broken specs (there are a few deprecations that I'm not bothering to get to)