### PR TITLE
Make branch names start with the name, downcased

### DIFF
--- a/lib/pivo_flow/pivotal.rb
+++ b/lib/pivo_flow/pivotal.rb
@@ -232,8 +232,12 @@ module PivoFlow
         return
       end
 
-      ticket_name = story.name.tr('^A-Za-z0-9 ', '').tr(' ', '-')
-      branch_name = [story.id, ticket_name].join("-")
+      ticket_name = story.name
+        .tr('^A-Za-z0-9 ', '')
+        .tr(' ', '-')
+        .downcase
+
+      branch_name = [ticket_name, story.id].join("-")
 
       git_create_branch(branch_name)
       save_story_id_to_file(story_id)


### PR DESCRIPTION
@lubieniebieski I changed the branch naming scheme, as it plays _way_ better with Bash completion. If the `story.id` is first, you have to do completion with a random number string that's hard to remember - it's much easier to remember the first few letters of the story name.