### PR TITLE
Put two newlines between commit title and tag

### DIFF
--- a/bin/pf-prepare-commit-msg
+++ b/bin/pf-prepare-commit-msg
@@ -12,7 +12,8 @@ if !branch_name.empty? && File.exists?(story_path)
 
     unless commit_msg.include?("##{$1}") or commit_msg =~ /Merge branch/
       File.open(ARGV[0], 'w') do |file|
-        file.print commit_msg
+        file.print commit_msg.strip
+        file.print "\n\n"
         file.print "[##{story_id}]"
       end
     end


### PR DESCRIPTION
@lubieniebieski When I go to edit a commit msg, my editor yells at me because the Git standard is to have two newlines after the first line of a commit msg.

**This is what currently happens (the `[#1345231412]` tag has a red warning)**
<img width="665" alt="screenshot 2017-10-05 07 50 35" src="https://user-images.githubusercontent.com/59429/31233828-50c6bcba-a9a2-11e7-9e98-5c42c5aecdb9.png">

**This is what my branch updates**
<img width="687" alt="screenshot 2017-10-05 07 50 42" src="https://user-images.githubusercontent.com/59429/31233869-62b44de8-a9a2-11e7-8cae-b6902c8c104c.png">
