### PR TITLE
Truncate feature branches to 50 chars

### DIFF
--- a/lib/pivo_flow/pivotal.rb
+++ b/lib/pivo_flow/pivotal.rb
@@ -224,6 +224,8 @@ module PivoFlow
       end
     end
 
+    MAX_BRANCH_NAME_LENGTH = 50
+
     def create_branch story_id
       story = find_story(story_id)
 
@@ -232,10 +234,11 @@ module PivoFlow
         return
       end
 
-      ticket_name = story.name
+      ticket_name = story
+        .name
         .tr('^A-Za-z0-9 ', '')
         .tr(' ', '-')
-        .downcase
+        .downcase[0...MAX_BRANCH_NAME_LENGTH]
 
       branch_name = [ticket_name, story.id].join("-")
 


### PR DESCRIPTION
@lubieniebieski Some of our branches are getting real crazy, especially Honeybadger-generated Pivotal Stories:

```[app/production] RuntimeError: Failed to create: #<ActiveModel::Errors:0x007faf78a4fc70 @base=#<User id: nil, email: "--redacted--", created_at: "2018-01-27 10:29:55", updated_at: "2018-01-27 10:29:55">, @messages={}, @details={}>```

This will at least truncate the branch title to 50 chars. People with slim terminal prompts will probably appreciate it anyways. Thoughts?