### PR TITLE
Cache bundler on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,15 @@ version: 2
 .build_template: &build_definition
   steps:
     - checkout
-    - run: bundle install
+    - restore_cache:
+        keys:
+          - v2-pivo-flow-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "pivo_flow.gemspec" }}
+          - v2-pivo-flow-bundle-{{ .Environment.CIRCLE_JOB }}-
+    - run: bundle check || bundle install
+    - save_cache:
+        key: v2-pivo-flow-bundle-{{ .Environment.CIRCLE_JOB }}-{{ checksum "pivo_flow.gemspec" }}
+        paths:
+          - /usr/local/bundle
     - run: bundle exec rspec --require spec_helper --format documentation --color spec
   working_directory: ~/app
 


### PR DESCRIPTION
@lubieniebieski Let's see if this works, but I noticed the bulk of your build is spent on bundle install, and it's real easy to cache it…