### PR TITLE
Fix branches that have slashes in them

### DIFF
--- a/lib/pivo_flow/state.rb
+++ b/lib/pivo_flow/state.rb
@@ -1,6 +1,6 @@
 module PivoFlow
   module State
-    extend self
+    module_function
 
     def current_branch_name
       Grit::Repo.new(Dir.pwd).head.name
@@ -11,7 +11,9 @@ module PivoFlow
     end
 
     def current_story_id_file_path
-      File.join(story_id_tmp_path, current_branch_name)
+      flat_branch_name = current_branch_name.gsub('/', '--')
+
+      File.join(story_id_tmp_path, flat_branch_name)
     end
 
     def current_story_id

--- a/spec/pivo_flow/state_spec.rb
+++ b/spec/pivo_flow/state_spec.rb
@@ -1,36 +1,46 @@
 require 'spec_helper'
 
 describe PivoFlow::State do
-  describe "#current_story_id_file_path" do
-    before do
-      allow(PivoFlow::State).to receive(:current_branch_name) { "cool-branch" }
-    end
+  describe '#current_story_id_file_path' do
+    it 'should return a path to a branch-based file name' do
+      with_branch_name 'cool-branch'
 
-    it "should return a path to a branch-based file name" do
       expect(PivoFlow::State.current_story_id_file_path).to eq(
         "#{Dir.pwd}/tmp/.pivo_flow/stories/cool-branch"
       )
     end
+
+    it 'should deal with slashes in the branch name' do
+      with_branch_name 'feature/my-cool-feature/a-thing'
+
+      expect(PivoFlow::State.current_story_id_file_path).to eq(
+        "#{Dir.pwd}/tmp/.pivo_flow/stories/feature--my-cool-feature--a-thing"
+      )
+    end
+
+    def with_branch_name(name)
+      allow(PivoFlow::State).to receive(:current_branch_name) { name }
+    end
   end
 
-  describe "#current_story_id" do
+  describe '#current_story_id' do
     let(:tmp_file) { "#{Dir.pwd}/tmp/.pivo_flow/stories/cool-branch" }
 
     before do
-      allow(PivoFlow::State).to receive(:current_branch_name) { "cool-branch" }
+      allow(PivoFlow::State).to receive(:current_branch_name) { 'cool-branch' }
 
       FileUtils.mkdir_p(PivoFlow::State.story_id_tmp_path)
-      File.write(tmp_file, "123456")
+      File.write(tmp_file, '123456')
     end
 
     after { FileUtils.remove_file(tmp_file) }
 
-    it "should read it from the tmp file" do
-      expect(PivoFlow::State.current_story_id).to eq("123456")
+    it 'should read it from the tmp file' do
+      expect(PivoFlow::State.current_story_id).to eq('123456')
     end
 
     it "should return nil if there's no file for it yet" do
-      allow(PivoFlow::State).to receive(:current_branch_name) { "different" }
+      allow(PivoFlow::State).to receive(:current_branch_name) { 'different' }
 
       expect(PivoFlow::State.current_story_id).to be_nil
     end


### PR DESCRIPTION
Hey @lubieniebieski,

Branches with slashes (e.g. `feature/blah-blah`) don't work in pivo_flow as that implicitly tries to write the story id file to a subfolder called `feature`, which typically doesn't exist.

This fixes things by stripping slashes out of the branch story file name.